### PR TITLE
implicit restore templates from restored indices, do not overwrite existing templates

### DIFF
--- a/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -248,8 +248,8 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                             }
                         }
 
-                        // restore templates which matches any restored index
-                        restoreTemplatesMatchingRestoredIndices(mdBuilder);
+                        // restore templates which matches any restored index (but do NOT overwrite existing templates)
+                        restoreTemplatesMatchingRestoredIndices(mdBuilder, currentState);
 
                         shards = shardsBuilder.build();
                         RestoreMetaData.Entry restoreEntry = new RestoreMetaData.Entry(snapshotId, RestoreMetaData.State.INIT, ImmutableList.copyOf(renamedIndices.keySet()), shards);
@@ -260,8 +260,8 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
 
                     checkAliasNameConflicts(renamedIndices, aliases);
 
-                    // Restore global state if needed
-                    restoreGlobalStateIfRequested(mdBuilder);
+                    // Restore global state if needed (but do NOT overwrite existing templates)
+                    restoreGlobalStateIfRequested(mdBuilder, currentState);
 
                     if (completed(shards)) {
                         // We don't have any indices to restore - we are done
@@ -366,11 +366,12 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                     return builder.settings(ImmutableSettings.builder().put(settingsMap)).build();
                 }
 
-                private void restoreTemplatesMatchingRestoredIndices(MetaData.Builder mdBuilder) {
+                private void restoreTemplatesMatchingRestoredIndices(MetaData.Builder mdBuilder, ClusterState currentState) {
                     if (metaData.templates() != null) {
                         for (ObjectCursor<IndexTemplateMetaData> cursor : metaData.templates().values()) {
                             for (String index : filteredIndices) {
-                                if (Regex.simpleMatch(cursor.value.template(), index)) {
+                                if (currentState.metaData().templates().get(cursor.value.name()) == null
+                                        && Regex.simpleMatch(cursor.value.template(), index)) {
                                     mdBuilder.put(cursor.value);
                                     break;
                                 }
@@ -379,7 +380,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                     }
                 }
 
-                private void restoreGlobalStateIfRequested(MetaData.Builder mdBuilder) {
+                private void restoreGlobalStateIfRequested(MetaData.Builder mdBuilder, ClusterState currentState) {
                     if (request.includeGlobalState()) {
                         if (metaData.persistentSettings() != null) {
                             boolean changed = false;
@@ -404,7 +405,9 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                         if (metaData.templates() != null) {
                             // TODO: Should all existing templates be deleted first?
                             for (ObjectCursor<IndexTemplateMetaData> cursor : metaData.templates().values()) {
-                                mdBuilder.put(cursor.value);
+                                if (currentState.metaData().templates().get(cursor.value.name()) == null) {
+                                    mdBuilder.put(cursor.value);
+                                }
                             }
                         }
                         if (metaData.customs() != null) {

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -480,6 +480,38 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
     }
 
     @Test
+    public void restoreTemplatesNotOverwritingExistingOnes() throws Exception {
+        Client client = client();
+
+        logger.info("-->  creating repository");
+        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
+                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", randomRepoPath())));
+
+        logger.info("-->  creating test template");
+        assertThat(client.admin().indices().preparePutTemplate("test-template").setTemplate("te*").addMapping("test-mapping", "{}").get().isAcknowledged(), equalTo(true));
+
+        logger.info("--> snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap").setIndices().setWaitForCompletion(true).get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().totalShards(), equalTo(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(0));
+        assertThat(client.admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-snap").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
+
+        logger.info("-->  update test template");
+        assertThat(client.admin().indices().preparePutTemplate("test-template").setTemplate("te*").addMapping("test-mapping", "abcde").get().isAcknowledged(), equalTo(true));
+
+        logger.info("--> restore cluster state");
+        RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setWaitForCompletion(true).setRestoreGlobalState(true).execute().actionGet();
+        // We don't restore any indices here
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
+
+        logger.info("--> check that template is NOT restored (already exists)");
+        GetIndexTemplatesResponse getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates("test-template").get();
+        assertThat(getIndexTemplatesResponse.getIndexTemplates(), hasSize(1));
+        assertThat(getIndexTemplatesResponse.getIndexTemplates().get(0).getMappings().size(), equalTo(1));
+        assertThat(getIndexTemplatesResponse.getIndexTemplates().get(0).getMappings().get("test-mapping").string(), equalTo("abcde"));
+    }
+
+    @Test
     public void includeGlobalStateTest() throws Exception {
         Client client = client();
 


### PR DESCRIPTION
this is needed to restore a partitioned table which includes a template while not restoring all templates in general (this would restore possible other partitioned tables inside a snapshot).
also prevent existing templates from being overwritten while restoring a snapshot in general.