### PR TITLE
Cherry-picked changes to resolve block.read_only being ignored with partitioned table bug.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -267,6 +267,15 @@ public class ClusterBlocks {
             return this;
         }
 
+        public Builder updateBlocks(IndexMetaData indexMetaData) {
+            removeIndexBlock(indexMetaData.index(), MetaDataIndexStateService.INDEX_CLOSED_BLOCK);
+            removeIndexBlock(indexMetaData.index(), IndexMetaData.INDEX_READ_ONLY_BLOCK);
+            removeIndexBlock(indexMetaData.index(), IndexMetaData.INDEX_READ_BLOCK);
+            removeIndexBlock(indexMetaData.index(), IndexMetaData.INDEX_WRITE_BLOCK);
+            removeIndexBlock(indexMetaData.index(), IndexMetaData.INDEX_METADATA_BLOCK);
+            return addBlocks(indexMetaData);
+        }
+
         public Builder addGlobalBlock(ClusterBlock block) {
             global.add(block);
             return this;

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -457,9 +457,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                             blocks.addIndexBlock(request.index(), block);
                         }
                     }
-                    if (request.state() == State.CLOSE) {
-                        blocks.addIndexBlock(request.index(), MetaDataIndexStateService.INDEX_CLOSED_BLOCK);
-                    }
+                    blocks.updateBlocks(indexMetaData);
 
                     ClusterState updatedState = ClusterState.builder(currentState).blocks(blocks).metaData(newMetaData).build();
 


### PR DESCRIPTION
Changes have been hand picked from ES commit 72b58fa46c51c2e1c8a2ae3f77e5791c917169f3