### PR TITLE
remove dateDetection

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -516,24 +516,6 @@ class DocumentParser implements Closeable {
                 }
             }
 
-            if (context.root().dateDetection()) {
-                String text = context.parser().text();
-                // a safe check since "1" gets parsed as well
-                if (Strings.countOccurrencesOf(text, ":") > 1 || Strings.countOccurrencesOf(text, "-") > 1 || Strings.countOccurrencesOf(text, "/") > 1) {
-                    for (FormatDateTimeFormatter dateTimeFormatter : context.root().dynamicDateTimeFormatters()) {
-                        try {
-                            dateTimeFormatter.parser().parseMillis(text);
-                            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "date");
-                            if (builder == null) {
-                                builder = MapperBuilders.dateField(currentFieldName).dateTimeFormatter(dateTimeFormatter);
-                            }
-                            return builder;
-                        } catch (Exception e) {
-                            // failure to parse this, continue
-                        }
-                    }
-                }
-            }
             if (context.root().numericDetection()) {
                 String text = context.parser().text();
                 try {

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -82,12 +82,11 @@ public class SimpleDateMappingTests extends ESSingleNodeTestCase {
         client().admin().indices().preparePutMapping("test").setType("type").setSource(doc.dynamicMappingsUpdate().toString()).get();
 
         FieldMapper fieldMapper = defaultMapper.mappers().smartNameFieldMapper("date_field1");
-        assertThat(fieldMapper, instanceOf(DateFieldMapper.class));
-        DateFieldMapper dateFieldMapper = (DateFieldMapper)fieldMapper;
-        assertEquals("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis", dateFieldMapper.fieldType().dateTimeFormatter().format());
-        assertEquals(1265587200000L, dateFieldMapper.fieldType().dateTimeFormatter().parser().parseMillis("1265587200000"));
+        assertThat(fieldMapper, instanceOf(StringFieldMapper.class));
+
+
         fieldMapper = defaultMapper.mappers().smartNameFieldMapper("date_field2");
-        assertThat(fieldMapper, instanceOf(DateFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(StringFieldMapper.class));
 
         fieldMapper = defaultMapper.mappers().smartNameFieldMapper("wrong_date1");
         assertThat(fieldMapper, instanceOf(StringFieldMapper.class));

--- a/core/src/test/java/org/elasticsearch/index/mapper/lucene/DoubleIndexingDocTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/lucene/DoubleIndexingDocTests.java
@@ -78,7 +78,8 @@ public class DoubleIndexingDocTests extends ESSingleNodeTestCase {
         topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field3").fieldType().termQuery("1.1", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field4").fieldType().termQuery("2010-01-01", null), 10);
+        // keyword-analyzer default: search only for 2010 token
+        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field4").fieldType().termQuery("2010", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
 
         topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").fieldType().termQuery("1", null), 10);

--- a/core/src/test/java/org/elasticsearch/index/mapper/numeric/SimpleNumericTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/numeric/SimpleNumericTests.java
@@ -352,7 +352,6 @@ public class SimpleNumericTests extends ESSingleNodeTestCase {
     public void testPrecisionStepDefaultsDetected() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .field("numeric_detection", true)
-                .field("date_detection", true)
                 .endObject().endObject().string();
 
         DocumentMapper mapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
@@ -361,7 +360,6 @@ public class SimpleNumericTests extends ESSingleNodeTestCase {
                 .startObject()
                 .field("long",   "100")
                 .field("double", "100.0")
-                .field("date",   "2010-01-01")
                 .endObject()
                 .bytes());
         
@@ -370,7 +368,6 @@ public class SimpleNumericTests extends ESSingleNodeTestCase {
         
         assertPrecisionStepEquals(NumberFieldMapper.Defaults.PRECISION_STEP_64_BIT, luceneDoc.getField("long"));
         assertPrecisionStepEquals(NumberFieldMapper.Defaults.PRECISION_STEP_64_BIT, luceneDoc.getField("double"));
-        assertPrecisionStepEquals(NumberFieldMapper.Defaults.PRECISION_STEP_64_BIT, luceneDoc.getField("date"));
     }
     
     /** Test default precision step for numeric types */


### PR DESCRIPTION
It's activated by default and we don't want that behaviour in Crate.

(Otherwise deactivating it would require a mapping migration)