### PR TITLE
Ab/gracefulstop bug fix

### DIFF
--- a/src/test/java/org/elasticsearch/cluster/graceful/GracefulStopIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/cluster/graceful/GracefulStopIntegrationTest.java
@@ -35,6 +35,8 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 public class GracefulStopIntegrationTest extends ElasticsearchIntegrationTest {
@@ -69,8 +71,10 @@ public class GracefulStopIntegrationTest extends ElasticsearchIntegrationTest {
 
     @After
     public void cleanUp() {
-        // reset to default
-        setSettings(false, true, "primaries", "2h");
+        client().admin().cluster().prepareUpdateSettings()
+                .setTransientSettingsToRemove(new HashSet<>(Arrays.asList(GracefulStop.SettingNames.FORCE,
+                        GracefulStop.SettingNames.REALLOCATE, Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY,
+                        GracefulStop.SettingNames.TIMEOUT)));
         gracefulStop = null;
         deallocators = null;
     }
@@ -78,10 +82,10 @@ public class GracefulStopIntegrationTest extends ElasticsearchIntegrationTest {
     protected void setSettings(boolean force, boolean reallocate, String minAvailability, String timeOut) {
         client().admin().cluster().prepareUpdateSettings()
                 .setTransientSettings(ImmutableSettings.builder()
-                        .put("cluster.graceful_stop.force", force)
-                        .put("cluster.graceful_stop.reallocate", reallocate)
-                        .put("cluster.graceful_stop.min_availability", minAvailability)
-                        .put("cluster.graceful_stop.timeout", timeOut)).execute().actionGet();
+                        .put(GracefulStop.SettingNames.FORCE, force)
+                        .put(GracefulStop.SettingNames.REALLOCATE, reallocate)
+                        .put(Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY, minAvailability)
+                        .put(GracefulStop.SettingNames.TIMEOUT, timeOut)).execute().actionGet();
     }
 
     /**

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocatorMinAvailibilityConfigTest.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocatorMinAvailibilityConfigTest.java
@@ -1,0 +1,36 @@
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.cluster.TestClusterService;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+public class DeallocatorMinAvailibilityConfigTest extends ElasticsearchTestCase {
+
+    private static final ClusterService CLUSTER_SERVICE = new TestClusterService();
+
+    @Test
+    public void testMinAvailibilityConfigRead() throws Exception {
+
+        Deallocators deallocFull = new Deallocators(CLUSTER_SERVICE,
+                new AllShardsDeallocator(CLUSTER_SERVICE, null, null),
+                new PrimariesDeallocator(CLUSTER_SERVICE, null, null, null),
+                ImmutableSettings.builder()
+                        .put(Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY,
+                                Deallocators.MinAvailability.FULL).build());
+
+        Deallocators deallocPrimary = new Deallocators(CLUSTER_SERVICE,
+                new AllShardsDeallocator(CLUSTER_SERVICE, null, null),
+                new PrimariesDeallocator(CLUSTER_SERVICE, null, null, null),
+                ImmutableSettings.builder()
+                        .put(Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY,
+                                Deallocators.MinAvailability.PRIMARIES).build());
+
+        assertThat(deallocFull.deallocator() instanceof AllShardsDeallocator, is(true));
+        assertThat(deallocPrimary.deallocator() instanceof PrimariesDeallocator, is(true));
+    }
+}


### PR DESCRIPTION
Deallocators in Graceful Stop were not reading config from .yml file and using configurations from cluster state of clusterService. Added config file configuration as a default config. 