### PR TITLE
fix: on restore, selecting indices can select wrong index

### DIFF
--- a/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
@@ -50,9 +50,10 @@ public class SnapshotUtils {
             boolean add = true;
             if (!indexOrPattern.isEmpty()) {
                 if (availableIndices.contains(indexOrPattern)) {
-                    if (result != null) {
-                        result.add(indexOrPattern);
+                    if (result == null) {
+                        result = new HashSet<>();
                     }
+                    result.add(indexOrPattern);
                     continue;
                 }
                 if (indexOrPattern.charAt(0) == '+') {

--- a/src/test/java/org/elasticsearch/snapshots/SnapshotUtilsTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SnapshotUtilsTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 /**
@@ -35,6 +34,7 @@ public class SnapshotUtilsTests extends ElasticsearchTestCase {
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"*"}, new String[]{"foo", "bar", "baz"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"foo", "bar", "baz"}, new String[]{"foo", "bar", "baz"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"foo"}, new String[]{"foo"});
+        assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"baz", "not_available"}, new String[]{"baz"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"ba*", "-bar", "-baz"}, new String[]{});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"-bar"}, new String[]{"foo", "baz"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"-ba*"}, new String[]{"foo"});


### PR DESCRIPTION
While restoring a snapshot with multiple indices inside, selecting concrete indices can result in a wrong index being restored. This happens if at least 1 selected index is not available inside the snapshot while another being available but not the first one at the available list.

Example:
  * Available indices in snapshot: ["foo", "bar" baz"]
  * Selected indices to restore: ["bar", "not_available"]
  * Resulting indices to be restored: ["foo"]

The test added at this patch will fail without the fix.