### PR TITLE
Correct logging about HttpServerModule override

### DIFF
--- a/core/src/main/java/org/elasticsearch/http/HttpServerModule.java
+++ b/core/src/main/java/org/elasticsearch/http/HttpServerModule.java
@@ -52,7 +52,7 @@ public class HttpServerModule extends AbstractModule {
     public void setHttpServerTransport(Class<? extends HttpServerTransport> httpServerTransport, String source) {
         Preconditions.checkNotNull(httpServerTransport, "Configured http server transport may not be null");
         Preconditions.checkNotNull(source, "Plugin, that changes transport may not be null");
-        logger.info("Using [{}] as http transport, overridden by [{}]", httpServerTransportClass.getName(), source);
+        logger.info("Using [{}] as http transport, overridden by [{}]", httpServerTransport.getName(), source);
         this.httpServerTransportClass = httpServerTransport;
     }
 }


### PR DESCRIPTION
It output the module in use *before* the override instead of what is
being used *after* the override.