### PR TITLE
do not allow restore of single partition snapshot

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -60,6 +60,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     private boolean includeGlobalState = true;
     private boolean partial = false;
     private boolean includeAliases = true;
+    private boolean checkForTemplates = false;
     private Settings settings = EMPTY_SETTINGS;
     private Settings indexSettings = EMPTY_SETTINGS;
     private String[] ignoreIndexSettings = Strings.EMPTY_ARRAY;
@@ -286,6 +287,21 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      */
     public RestoreSnapshotRequest partial(boolean partial) {
         this.partial = partial;
+        return this;
+    }
+
+    /**
+     *
+     */
+    public boolean checkForTemplates() {
+        return checkForTemplates;
+    }
+
+    /**
+     * Set to true to enforce presence of index templates for aliases.
+     */
+    public RestoreSnapshotRequest checkForTemplates(boolean checkForTemplates) {
+        this.checkForTemplates = checkForTemplates;
         return this;
     }
 
@@ -624,6 +640,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         includeGlobalState = in.readBoolean();
         partial = in.readBoolean();
         includeAliases = in.readBoolean();
+        checkForTemplates = in.readBoolean();
         settings = readSettingsFromStream(in);
         indexSettings = readSettingsFromStream(in);
         ignoreIndexSettings = in.readStringArray();
@@ -642,6 +659,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         out.writeBoolean(includeGlobalState);
         out.writeBoolean(partial);
         out.writeBoolean(includeAliases);
+        out.writeBoolean(checkForTemplates);
         writeSettingsToStream(settings, out);
         writeSettingsToStream(indexSettings, out);
         out.writeStringArray(ignoreIndexSettings);

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
@@ -214,6 +214,16 @@ public class RestoreSnapshotRequestBuilder extends MasterNodeOperationRequestBui
     }
 
     /**
+     *
+     * @param checkForTemplates
+     * @return
+     */
+    public RestoreSnapshotRequestBuilder setCheckForTemplates(boolean checkForTemplates) {
+        request.checkForTemplates(checkForTemplates);
+        return this;
+    }
+
+    /**
      * If set to true the restore procedure will restore aliases
      *
      * @param restoreAliases true if aliases should be restored from the snapshot

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -73,13 +73,14 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<Re
 
     @Override
     protected void masterOperation(final RestoreSnapshotRequest request, ClusterState state, final ActionListener<RestoreSnapshotResponse> listener) {
-        RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(
+        final RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(
                 "restore_snapshot[" + request.snapshot() + "]", request.repository(), request.snapshot(),
                 request.indices(), request.indicesOptions(), request.renamePattern(), request.renameReplacement(),
                 request.settings(), request.masterNodeTimeout(), request.includeGlobalState(), request.partial(), request.includeAliases(),
-                request.indexSettings(), request.ignoreIndexSettings());
+                request.checkForTemplates(), request.ignoreIndexSettings(), request.indexSettings());
 
         restoreService.restoreSnapshot(restoreRequest, new ActionListener<RestoreInfo>() {
+
             @Override
             public void onResponse(RestoreInfo restoreInfo) {
                 if (restoreInfo == null && request.waitForCompletion()) {


### PR DESCRIPTION
restoring a snapshot of a single partition into a non-existent table would create an orphaned partition.
this fix checks whether the template/table for the partition that should be restored exists already in the current cluster state and whether the snapshot has a template that matches with the restored partition.

@mfussenegger can you take a look