### PR TITLE
add support for custom index and template metadata upgrade hooks

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/CustomUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/CustomUpgradeService.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+public interface CustomUpgradeService {
+
+    /**
+     * Upgrades a given {@link IndexMetaData} to the current version.
+     *
+     * If no upgrade is required, the index metadata must be returned unchanged, otherwise a modified index metadata
+     * is expected. If the index cannot be updated an exception should be thrown.
+     */
+    IndexMetaData upgradeIndexMetaData(IndexMetaData indexMetaData);
+
+    /**
+     * Upgrades a given {@link IndexTemplateMetaData} to the current version.
+     *
+     * If no upgrade is required, the template metadata must be returned unchanged, otherwise a modified template
+     * metadata is expected. If the template cannot be updated an exception should be thrown.
+     */
+    IndexTemplateMetaData upgradeIndexTemplateMetaData(IndexTemplateMetaData indexTemplateMetaData);
+
+}

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/CustomUpgradeServiceProvider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/CustomUpgradeServiceProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Provider;
+
+/**
+ *  Provides a {@link CustomUpgradeService} if one is bound, else this provider returns a NOOP default implementation.
+ *
+ *  Adds possibility for plugins to register custom index metadata upgrade hooks.
+ */
+public class CustomUpgradeServiceProvider implements Provider<CustomUpgradeService> {
+
+    private static final CustomUpgradeService NOOP_SERVICE = new CustomUpgradeService() {
+        @Override
+        public IndexMetaData upgradeIndexMetaData(IndexMetaData indexMetaData) {
+            return indexMetaData;
+        }
+
+        @Override
+        public IndexTemplateMetaData upgradeIndexTemplateMetaData(IndexTemplateMetaData indexTemplateMetaData) {
+            return indexTemplateMetaData;
+        }
+    };
+
+    @Inject(optional = true)
+    public CustomUpgradeService customUpgradeService;
+
+    @Override
+    public CustomUpgradeService get() {
+        if (customUpgradeService == null) {
+            return NOOP_SERVICE;
+        }
+        return customUpgradeService;
+    }
+}


### PR DESCRIPTION
plugins can bind a CustomUpgradeService which will be triggered
on local gateway state recovery and restoring indices of snapshots