### PR TITLE
Move the registration of custom recovery source handler to PeerRecoverySourceService.

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -19,13 +19,10 @@
 
 package org.elasticsearch.indices.recovery;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.store.RateLimiter.SimpleRateLimiter;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -33,12 +30,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.index.shard.IndexShard;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 public class RecoverySettings extends AbstractComponent {
 
@@ -83,9 +74,6 @@ public class RecoverySettings extends AbstractComponent {
             Property.Dynamic, Property.NodeScope);
 
     public static final ByteSizeValue DEFAULT_CHUNK_SIZE = new ByteSizeValue(512, ByteSizeUnit.KB);
-
-    // CRATE_PATCH: used to register BlobRecoverySourceHandler
-    private final List<RecoverySourceHandlerProvider> recoverySourceHandlerProviders = new ArrayList<>();
 
     private volatile ByteSizeValue maxBytesPerSec;
     private volatile SimpleRateLimiter rateLimiter;
@@ -192,26 +180,4 @@ public class RecoverySettings extends AbstractComponent {
             rateLimiter = new SimpleRateLimiter(maxBytesPerSec.getMbFrac());
         }
     }
-
-    @Nullable
-    RecoverySourceHandler getCustomRecoverySourceHandler(IndexShard shard,
-                                                         RemoteRecoveryTargetHandler recoveryTarget,
-                                                         StartRecoveryRequest request,
-                                                         Supplier<Long> currentClusterStateVersionSupplier,
-                                                         Function<String, Releasable> delayNewRecoveries,
-                                                         Logger logger){
-        for (RecoverySourceHandlerProvider recoverySourceHandlerProvider : recoverySourceHandlerProviders) {
-            RecoverySourceHandler handler = recoverySourceHandlerProvider.get(
-                shard, request, recoveryTarget, delayNewRecoveries, currentClusterStateVersionSupplier, logger);
-            if (handler != null) {
-                return handler;
-            }
-        }
-        return null;
-    }
-
-    public void registerRecoverySourceHandlerProvider(RecoverySourceHandlerProvider provider){
-        recoverySourceHandlerProviders.add(provider);
-    }
-
 }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerProvider.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerProvider.java
@@ -36,6 +36,7 @@ public interface RecoverySourceHandlerProvider {
                               StartRecoveryRequest request,
                               RemoteRecoveryTargetHandler recoveryTarget,
                               Function<String, Releasable> delayNewRecoveries,
+                              int fileChunkSizeInBytes,
                               Supplier<Long> currentClusterStateVersionSupplier,
                               Logger logger);
 }


### PR DESCRIPTION
RecoverySettings will not be available for discovery via guice anymore starting with es 5.3.
As RecoverySettings was patched to hold the custom recovery source handlers and we'll need to
patch ES to get access to RecoverySettings, with this patch we moved all the custom state from
RecoverySettings in PeerRecoverySourceService (basically unpatched RecoverySettings).