### PR TITLE
ec2-discovery: set current region if no endpoint available

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
@@ -27,6 +27,8 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.http.IdleConnectionReaper;
 import com.amazonaws.internal.StaticCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
@@ -64,6 +66,12 @@ public class AwsEc2ServiceImpl extends AbstractLifecycleComponent implements Aws
         String endpoint = findEndpoint(logger, settings);
         if (endpoint != null) {
             client.setEndpoint(endpoint);
+        } else {
+            Region currentRegion = Regions.getCurrentRegion();
+            if (currentRegion != null) {
+                logger.debug("using ec2 region [{}]", currentRegion);
+                client.setRegion(currentRegion);
+            }
         }
 
         return this.client;


### PR DESCRIPTION
The AwsEc2ServiceImpl instantiates a client and sets the endpoint which
can be specified explicitly by the ``ENDPOINT_SETTING`` or the
``REGION_SETTING``. If none of these settings are provided the client
would fall back to the endpoint of the ``us-east-1`` region.
This change however sets the client's region based on the region of the
running EC2 instance which can be obtained by an API call to the
instance metadata.

This behaviour was already patched in version 2.4.x of the Crate fork of
Elasticsearch and was accidentally removed with the ES5 upgrade.