### PR TITLE
changes default of waitForActiveShards to ALL

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 final class AutoExpandReplicas {
     // the value we recognize in the "max" position to mean all the nodes
     private static final String ALL_NODES_VALUE = "all";
-    public static final Setting<AutoExpandReplicas> SETTING = new Setting<>(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false", (value) -> {
+    public static final Setting<AutoExpandReplicas> SETTING = new Setting<>(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1", (value) -> {
         final int min;
         final int max;
         if (Booleans.parseBoolean(value, true) == false) {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -64,7 +64,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -254,7 +253,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
      */
     public static final Setting<ActiveShardCount> SETTING_WAIT_FOR_ACTIVE_SHARDS =
         new Setting<>("index.write.wait_for_active_shards",
-                      "1",
+                      "all",
                       ActiveShardCount::parseString,
                       Setting.Property.Dynamic,
                       Setting.Property.IndexScope);

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainTests.java
@@ -31,7 +31,8 @@ public final class ClusterAllocationExplainTests extends ESSingleNodeTestCase {
 
     public void testShardExplain() throws Exception {
         client().admin().indices().prepareCreate("test")
-                .setSettings("index.number_of_shards", 1, "index.number_of_replicas", 1).get();
+                .setSettings("index.number_of_shards", 1, "index.number_of_replicas", 1,
+                    "index.auto_expand_replicas", false, "index.write.wait_for_active_shards", 1).get();
         ClusterAllocationExplainResponse resp = client().admin().cluster().prepareAllocationExplain()
                 .setIndex("test").setShard(0).setPrimary(false).get();
 

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -23,8 +23,10 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
@@ -122,7 +124,8 @@ public class ClusterStatsIT extends ESIntegTestCase {
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
 
-        prepareCreate("test1").setSettings("number_of_shards", 2, "number_of_replicas", 1).get();
+        prepareCreate("test1").setSettings("number_of_shards", 2, "number_of_replicas", 1,
+            IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false, IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE).get();
 
         response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.YELLOW));
@@ -140,7 +143,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         assertThat(response.indicesStats.getDocs().getCount(), Matchers.equalTo(1L));
         assertShardStats(response.getIndicesStats().getShards(), 1, 4, 2, 1.0);
 
-        prepareCreate("test2").setSettings("number_of_shards", 3, "number_of_replicas", 0).get();
+        prepareCreate("test2").setSettings("number_of_shards", 3, "number_of_replicas", 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false).get();
         ensureGreen();
         response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -419,7 +419,8 @@ public class CreateIndexIT extends ESIntegTestCase {
         internalCluster().ensureAtLeastNumDataNodes(2);
         prepareCreate("source").setSettings(Settings.builder().put(indexSettings())
             .put("number_of_shards", randomIntBetween(2, 7))
-            .put("number_of_replicas", 0)).get();
+            .put("number_of_replicas", 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")).get();
         for (int i = 0; i < 20; i++) {
             client().prepareIndex("source", randomFrom("t1", "t2", "t3")).setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}").get();
         }
@@ -444,6 +445,7 @@ public class CreateIndexIT extends ESIntegTestCase {
             .setSettings(Settings.builder()
             .put("index.routing.allocation.exclude._name", mergeNode) // we manually exclude the merge node to forcefully fuck it up
             .put("index.number_of_replicas", 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
             .put("index.allocation.max_retries", 1).build()).get();
 
         // now we move all shards away from the merge node
@@ -491,6 +493,7 @@ public class CreateIndexIT extends ESIntegTestCase {
                                 .put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), Integer.toString(numReplicas))
                                 .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                                 .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), numReplicas)
+                                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
                                 .build();
         assertAcked(client().admin().indices().prepareCreate("test-idx-1").setSettings(settings).get());
 

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -88,6 +88,7 @@ public class RolloverIT extends ESIntegTestCase {
         final Settings settings = Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
             .build();
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias")
             .settings(settings).alias(new Alias("extra_alias")).get();

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -59,6 +59,7 @@ public class TransportRolloverActionTests extends ESTestCase {
             .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
             .build();
         final IndexMetaData metaData = IndexMetaData.builder(randomAsciiOfLength(10))
             .creationDate(System.currentTimeMillis() - TimeValue.timeValueHours(3).getMillis())
@@ -131,6 +132,7 @@ public class TransportRolloverActionTests extends ESTestCase {
             .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
             .build();
         final MetaData metaData = MetaData.builder()
             .put(IndexMetaData.builder(index1)

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -80,6 +80,7 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         assertAcked(prepareCreate(index).setSettings(Settings.builder()
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "2")
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "1")
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
         ));
         indexRandomData(index);
         ensureGreen(index);

--- a/core/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
@@ -108,8 +108,8 @@ public class ActiveShardCountTests extends ESTestCase {
     }
 
     public void testEnoughShardsActiveLevelDefault() {
-        // default is 1
-        runTestForOneActiveShard(ActiveShardCount.DEFAULT);
+        // default is "all"
+        runTestForAllActiveShard(ActiveShardCount.DEFAULT);
     }
 
     public void testEnoughShardsActiveRandom() {
@@ -175,6 +175,20 @@ public class ActiveShardCountTests extends ESTestCase {
         assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
         clusterState = startPrimaries(clusterState, indexName);
         assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        clusterState = startAllShards(clusterState, indexName);
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+    }
+
+    private void runTestForAllActiveShard(final ActiveShardCount activeShardCount) {
+        final String indexName = "test-idx";
+        final int numberOfShards = randomIntBetween(1, 5);
+        final int numberOfReplicas = randomIntBetween(4, 7);
+        assert activeShardCount == ActiveShardCount.DEFAULT;
+        final ActiveShardCount waitForActiveShards = activeShardCount;
+        ClusterState clusterState = initializeWithNewIndex(indexName, numberOfShards, numberOfReplicas);
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        clusterState = startPrimaries(clusterState, indexName);
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
         clusterState = startAllShards(clusterState, indexName);
         assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
     }

--- a/core/src/test/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
+++ b/core/src/test/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_AUTO_EXPAND_REPLICAS_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -109,6 +110,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
                                 .put(indexSettings())
                                 .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), randomIntBetween(1, 5))
                                 .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), numReplicas)
+                                .put(INDEX_AUTO_EXPAND_REPLICAS_SETTING.getKey(), "false")
                                 .build();
         final String indexName = "test-idx";
         assertFalse(prepareCreate(indexName)

--- a/core/src/test/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -205,7 +205,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         // start a second node, create an index, and then shut it down so we have no master block
         internalCluster().startNode(settings);
         prepareCreate("test1").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).get();
-        prepareCreate("test2").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 2, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).get();
+        prepareCreate("test2").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 2, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false).get();
         client().admin().cluster().prepareHealth("_all").setWaitForGreenStatus().get();
         client().prepareIndex("test1", "type1", "1").setSource("field", "value1").get();
         client().prepareIndex("test2", "type1", "1").setSource("field", "value1").get();

--- a/core/src/test/java/org/elasticsearch/cluster/ack/AckIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ack/AckIT.java
@@ -36,7 +36,6 @@ import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
-import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.index.Index;
@@ -46,6 +45,7 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -123,7 +123,8 @@ public class AckIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate("test")
                 .setSettings(Settings.builder()
                         .put(SETTING_NUMBER_OF_SHARDS, between(cluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
-                        .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
+                        .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put(SETTING_AUTO_EXPAND_REPLICAS, "false")).get();
         ensureGreen();
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();
@@ -136,7 +137,8 @@ public class AckIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate("test")
                 .setSettings(Settings.builder()
                         .put(SETTING_NUMBER_OF_SHARDS, between(cluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
-                        .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
+                        .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put(SETTING_AUTO_EXPAND_REPLICAS, "false")).get();
         ensureGreen();
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();
@@ -171,7 +173,8 @@ public class AckIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate("test")
                 .setSettings(Settings.builder()
                         .put(SETTING_NUMBER_OF_SHARDS, between(cluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
-                        .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
+                        .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put(SETTING_AUTO_EXPAND_REPLICAS, "false")).get();
         ensureGreen();
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();

--- a/core/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -93,7 +94,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
 
         logger.info("--> create an index with 1 shard, 1 replica, nothing should allocate");
         client().admin().indices().prepareCreate("test").setWaitForActiveShards(ActiveShardCount.NONE)
-                .setSettings(Settings.builder().put("index.number_of_shards", 1))
+                .setSettings(Settings.builder().put("index.number_of_shards", 1).put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false"))
                 .execute().actionGet();
 
         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
@@ -182,6 +183,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             client().admin().indices().prepareCreate("test" + i)
                     .setSettings(Settings.builder()
                             .put("index.number_of_shards", 5).put("index.number_of_replicas", 1)
+                            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
                             .put("index.unassigned.node_left.delayed_timeout", randomIntBetween(250, 1000) + "ms"))
                     .execute().actionGet();
         }
@@ -205,7 +207,9 @@ public class ClusterRerouteIT extends ESIntegTestCase {
 
         logger.info("--> create an index with 1 shard, 1 replica, nothing should allocate");
         client().admin().indices().prepareCreate("test").setWaitForActiveShards(ActiveShardCount.NONE)
-                .setSettings(Settings.builder().put("index.number_of_shards", 1))
+                .setSettings(Settings.builder().put("index.number_of_shards", 1)
+                    .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                    .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE))
                 .execute().actionGet();
 
         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
@@ -309,7 +313,9 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         List<String> nodesIds = internalCluster().startNodesAsync(2).get();
 
         logger.info("--> create an index with 1 shard and 0 replicas");
-        assertAcked(prepareCreate("test-blocks").setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0)));
+        assertAcked(prepareCreate("test-blocks").setSettings(Settings.builder()
+            .put("index.number_of_shards", 1).put("index.number_of_replicas", 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")));
         ensureGreen("test-blocks");
 
         logger.info("--> check that the index has 1 shard");

--- a/core/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.allocation;
 
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -50,7 +51,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
 
         logger.info("--> creating an index with no replicas");
         client().admin().indices().prepareCreate("test")
-                .setSettings(Settings.builder().put("index.number_of_replicas", 0))
+                .setSettings(Settings.builder().put("index.number_of_replicas", 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false"))
                 .execute().actionGet();
         ensureGreen();
         logger.info("--> index some data");
@@ -89,7 +90,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
 
         logger.info("--> creating an index with no replicas");
         client().admin().indices().prepareCreate("test")
-                .setSettings(Settings.builder().put("index.number_of_replicas", 0))
+                .setSettings(Settings.builder().put("index.number_of_replicas", 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false"))
                 .execute().actionGet();
 
         ensureGreen();

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -516,7 +516,9 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
     }
 
     private IndexMetaData.Builder indexBuilder(String index) {
-        return IndexMetaData.builder(index).settings(settings(Version.CURRENT).put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
+        return IndexMetaData.builder(index).settings(settings(Version.CURRENT)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
     }
 
     public void testConcreteIndicesIgnoreIndicesOneMissingIndex() {

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -126,7 +126,9 @@ public class WildcardExpressionResolverTests extends ESTestCase {
     }
 
     private IndexMetaData.Builder indexBuilder(String index) {
-        return IndexMetaData.builder(index).settings(settings(Version.CURRENT).put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
+        return IndexMetaData.builder(index).settings(settings(Version.CURRENT)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDeciderIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDeciderIT.java
@@ -41,8 +41,14 @@ public class EnableAllocationDeciderIT extends ESIntegTestCase {
         // we test with 2 shards since otherwise it's pretty fragile if there are difference in the num or shards such that
         // all shards are relocated to the second node which is not what we want here. It's solely a test for the settings to take effect
         final int numShards = 2;
-        assertAcked(prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numShards)));
-        assertAcked(prepareCreate("test_1").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numShards)));
+        assertAcked(prepareCreate("test").setSettings(Settings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numShards)));
+        assertAcked(prepareCreate("test_1").setSettings(Settings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numShards)));
         ensureGreen();
         assertAllShardsOnNodes("test", firstNode);
         assertAllShardsOnNodes("test_1", firstNode);

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.MockInternalClusterInfoService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -82,6 +83,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
         prepareCreate("test").setSettings(Settings.builder()
                 .put("number_of_shards", 10)
                 .put("number_of_replicas", 0)
+                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 .put("index.routing.allocation.exclude._name", "")).get();
         ensureGreen("test");
 

--- a/core/src/test/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.shards;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsGroup;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -54,7 +55,10 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
 
     public void testSingleShardAllocation() throws Exception {
         client().admin().indices().prepareCreate("test").setSettings(Settings.builder()
-                .put("index.number_of_shards", "1").put("index.number_of_replicas", 0).put("index.routing.allocation.include.tag", "A")).execute().actionGet();
+            .put("index.number_of_shards", "1")
+            .put("index.number_of_replicas", 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
+            .put("index.routing.allocation.include.tag", "A")).execute().actionGet();
         ensureGreen();
         ClusterSearchShardsResponse response = client().admin().cluster().prepareSearchShards("test").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(1));
@@ -76,7 +80,10 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
 
     public void testMultipleShardsSingleNodeAllocation() throws Exception {
         client().admin().indices().prepareCreate("test").setSettings(Settings.builder()
-                .put("index.number_of_shards", "4").put("index.number_of_replicas", 0).put("index.routing.allocation.include.tag", "A")).execute().actionGet();
+            .put("index.number_of_shards", "4")
+            .put("index.number_of_replicas", 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
+            .put("index.routing.allocation.include.tag", "A")).execute().actionGet();
         ensureGreen();
 
         ClusterSearchShardsResponse response = client().admin().cluster().prepareSearchShards("test").execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -318,6 +319,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 2)
+                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
         ));
 
         // Everything is stable now, it is now time to simulate evil...
@@ -401,6 +403,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
                 .setSettings(Settings.builder()
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1 + randomInt(2))
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomInt(2))
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 ));
 
         ensureGreen();
@@ -476,6 +479,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
                 .setSettings(Settings.builder()
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1 + randomInt(2))
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomInt(2))
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 ));
         ensureGreen();
 
@@ -774,6 +778,8 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
                 .setSettings(Settings.builder()
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 2)
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
+                        .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE)
                 )
                 .get());
         ensureGreen("test");
@@ -1099,6 +1105,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(
                 Settings.builder().put(indexSettings())
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0))
         );
         ensureGreen("test");
@@ -1224,7 +1231,8 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
 
         assertAcked(client(randomFrom(nonPreferredNodes)).admin().indices().prepareCreate("test").setSettings(
             INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1,
-            INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0
+            INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0,
+            IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false
         ));
 
         internalCluster().clearDisruptionScheme(false);

--- a/core/src/test/java/org/elasticsearch/document/ShardInfoIT.java
+++ b/core/src/test/java/org/elasticsearch/document/ShardInfoIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -109,7 +110,9 @@ public class ShardInfoIT extends ESIntegTestCase {
         assertAcked(prepareCreate("idx").setSettings(
                 Settings.builder()
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numberOfPrimaryShards)
-                        .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, numCopies - 1))
+                        .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, numCopies - 1)
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                        .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE))
                 .addMapping("type", "_routing", "required=" + routingRequired)
                 .get());
         for (int i = 0; i < numberOfPrimaryShards; i++) {

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsIntegrationIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.fieldstats.FieldStatsAction;
 import org.elasticsearch.action.fieldstats.FieldStatsResponse;
 import org.elasticsearch.action.fieldstats.IndexConstraint;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.index.cache.request.RequestCacheStats;
 import org.elasticsearch.test.ESIntegTestCase;
 
@@ -491,7 +492,8 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
     }
 
     public void testCached() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings("index.number_of_replicas", 0));
+        assertAcked(client().admin().indices().prepareCreate("test")
+            .setSettings("index.number_of_replicas", 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false"));
         indexRange("test", "value", 0, 99);
 
         // First query should be a cache miss

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
@@ -63,7 +63,10 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
         String node2 = nodeName2.get();
 
         String index = "index";
-        assertAcked(prepareCreate(index).setSettings(Settings.builder().put("index.number_of_replicas", 0).put(IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "_name", node1)));
+        assertAcked(prepareCreate(index).setSettings(Settings.builder()
+            .put("index.number_of_replicas", 0)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
+            .put(IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "_name", node1)));
         index(index, "doc", "1", jsonBuilder().startObject().field("text", "some text").endObject());
         ensureGreen();
         assertIndexInMetaState(node1, index);

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -746,6 +747,7 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
         Settings idxSettings = Settings.builder()
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 5)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
                 .put(IndexMetaData.SETTING_DATA_PATH, dataPath.toAbsolutePath().toString())
                 .put(IndexMetaData.SETTING_SHARED_FILESYSTEM, true)
                 .put(IndexMetaData.SETTING_SHARED_FS_ALLOW_RECOVERY_ON_ANY_NODE, true)
@@ -856,6 +858,8 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
         Settings idxSettings = Settings.builder()
                                        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                                        .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 2)
+                                       .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                                       .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE)
                                        .put(IndexMetaData.SETTING_DATA_PATH, dataPath.toAbsolutePath().toString())
                                        .put(IndexMetaData.SETTING_SHADOW_REPLICAS, true)
                                        .put(IndexMetaData.SETTING_SHARED_FILESYSTEM, true)

--- a/core/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/core/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -147,6 +147,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "1")
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "1")
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
             .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)
             .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false) // no checkindex - we corrupt shards on purpose
             .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB)) // no translog based flush - it might change the .liv / segments.N files
@@ -251,6 +252,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
 
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "0")
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
             .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)
             .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false) // no checkindex - we corrupt shards on purpose
             .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB)) // no translog based flush - it might change the .liv / segments.N files
@@ -332,6 +334,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         NodeStats unluckyNode = dataNodeStats.get(1);
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "0")
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put("index.routing.allocation.include._name", primariesNode.getNode().getName())
             .put(EnableAllocationDecider.INDEX_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), EnableAllocationDecider.Rebalance.NONE)
@@ -395,6 +398,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
 
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "0")
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, between(1, 4)) // don't go crazy here it must recovery fast
             // This does corrupt files on the replica, so we can't check:
             .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false)
@@ -480,6 +484,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
 
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "0") // no replicas for this test
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
                         .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)
                         .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false) // no checkindex - we corrupt shards on purpose
                         .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB)) // no translog based flush - it might change the .liv / segments.N files
@@ -534,6 +539,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
             .put(PrimaryShardAllocator.INDEX_RECOVERY_INITIAL_SHARDS_SETTING.getKey(), "one")
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, cluster().numDataNodes() - 1)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
             .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)
             .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false) // no checkindex - we corrupt shards on purpose
             .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(),

--- a/core/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -67,11 +68,13 @@ public class SuggestStatsIT extends ESIntegTestCase {
         assertThat(numNodes, lessThanOrEqualTo(totalShards));
         assertAcked(prepareCreate("test1").setSettings(Settings.builder()
                 .put(SETTING_NUMBER_OF_SHARDS, shardsIdx1)
-                .put(SETTING_NUMBER_OF_REPLICAS, 0))
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(SETTING_AUTO_EXPAND_REPLICAS, "false"))
                 .addMapping("type", "f", "type=text"));
         assertAcked(prepareCreate("test2").setSettings(Settings.builder()
                 .put(SETTING_NUMBER_OF_SHARDS, shardsIdx2)
-                .put(SETTING_NUMBER_OF_REPLICAS, 0))
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(SETTING_AUTO_EXPAND_REPLICAS, "false"))
                 .addMapping("type", "f", "type=text"));
         assertThat(shardsIdx1 + shardsIdx2, equalTo(numAssignedShards("test1", "test2")));
         assertThat(numAssignedShards("test1", "test2"), greaterThanOrEqualTo(2));

--- a/core/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
@@ -52,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.index.shard.IndexShardState.CLOSED;
@@ -122,7 +123,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
      */
     public void testIndexShardFailedOnRelocation() throws Throwable {
         String node1 = internalCluster().startNode();
-        client().admin().indices().prepareCreate("index1").setSettings(SETTING_NUMBER_OF_SHARDS, 1, SETTING_NUMBER_OF_REPLICAS, 0).get();
+        client().admin().indices().prepareCreate("index1").setSettings(SETTING_NUMBER_OF_SHARDS, 1, SETTING_NUMBER_OF_REPLICAS, 0, SETTING_AUTO_EXPAND_REPLICAS, "false").get();
         ensureGreen("index1");
         String node2 = internalCluster().startNode();
         internalCluster().getInstance(MockIndexEventListener.TestEventListener.class, node2).setNewDelegate(new IndexShardStateChangeListener() {
@@ -159,7 +160,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
 
         //create an index
         assertAcked(client().admin().indices().prepareCreate("test")
-                .setSettings(SETTING_NUMBER_OF_SHARDS, 6, SETTING_NUMBER_OF_REPLICAS, 0));
+                .setSettings(SETTING_NUMBER_OF_SHARDS, 6, SETTING_NUMBER_OF_REPLICAS, 0, SETTING_AUTO_EXPAND_REPLICAS, "false"));
         ensureGreen();
         assertThat(stateChangeListenerNode1.creationSettings.getAsInt(SETTING_NUMBER_OF_SHARDS, -1), equalTo(6));
         assertThat(stateChangeListenerNode1.creationSettings.getAsInt(SETTING_NUMBER_OF_REPLICAS, -1), equalTo(0));

--- a/core/src/test/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
@@ -90,7 +90,8 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().prepareCreate("index").addMapping("type", "s", "type=date")
                 .setSettings(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true,
                         IndexMetaData.SETTING_NUMBER_OF_SHARDS, 5,
-                        IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                        IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0,
+                        IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 .get());
         indexRandom(true, client().prepareIndex("index", "type", "1").setRouting("1").setSource("s", "2016-03-19"),
                 client().prepareIndex("index", "type", "2").setRouting("1").setSource("s", "2016-03-20"),
@@ -139,7 +140,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
     public void testQueryRewriteMissingValues() throws Exception {
         assertAcked(client().admin().indices().prepareCreate("index").addMapping("type", "s", "type=date")
                 .setSettings(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true, IndexMetaData.SETTING_NUMBER_OF_SHARDS,
-                        1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                        1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 .get());
         indexRandom(true, client().prepareIndex("index", "type", "1").setSource("s", "2016-03-19"),
                 client().prepareIndex("index", "type", "2").setSource("s", "2016-03-20"),
@@ -189,7 +190,8 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().prepareCreate("index").addMapping("type", "d", "type=date")
                 .setSettings(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true,
                         IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1,
-                        IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                        IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0,
+                        IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 .get());
         indexRandom(true, client().prepareIndex("index", "type", "1").setSource("d", "2014-01-01T00:00:00"),
                 client().prepareIndex("index", "type", "2").setSource("d", "2014-02-01T00:00:00"),
@@ -241,15 +243,15 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
     public void testQueryRewriteDatesWithNow() throws Exception {
         assertAcked(client().admin().indices().prepareCreate("index-1").addMapping("type", "d", "type=date")
                 .setSettings(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true, IndexMetaData.SETTING_NUMBER_OF_SHARDS,
-                        1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                        1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 .get());
         assertAcked(client().admin().indices().prepareCreate("index-2").addMapping("type", "d", "type=date")
                 .setSettings(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true, IndexMetaData.SETTING_NUMBER_OF_SHARDS,
-                        1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                        1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 .get());
         assertAcked(client().admin().indices().prepareCreate("index-3").addMapping("type", "d", "type=date")
                 .setSettings(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true, IndexMetaData.SETTING_NUMBER_OF_SHARDS,
-                        1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                        1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 .get());
         DateTime now = new DateTime(ISOChronology.getInstanceUTC());
         indexRandom(true, client().prepareIndex("index-1", "type", "1").setSource("d", now),

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.common.Priority;
@@ -48,7 +49,10 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
     public void testPrimaryRelocationWhileIndexing() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(randomIntBetween(2, 3));
         client().admin().indices().prepareCreate("test")
-            .setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+            .setSettings(Settings.builder()
+                .put("index.number_of_shards", 1)
+                .put("index.number_of_replicas", 0)
+                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false"))
             .addMapping("type", "field", "type=text")
             .get();
         ensureGreen("test");

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -575,6 +575,7 @@ public class IndexRecoveryIT extends ESIntegTestCase {
                                 .put(IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "color", "blue")
                                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
                 ).get();
 
         List<IndexRequestBuilder> requests = new ArrayList<>();

--- a/core/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -226,6 +227,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
         assertAcked(prepareCreate("index").setSettings(Settings.builder()
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false)
                 .put("index.routing.allocation.exclude._name", master)).get());
         ensureGreen();
 
@@ -342,6 +344,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
         assertAcked(prepareCreate("index").setSettings(Settings.builder()
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE)
                 .put("index.routing.allocation.include._name", master)).get());
         assertAcked(client().admin().indices().prepareUpdateSettings("index").setSettings(Settings.builder()
                 .put("index.routing.allocation.include._name", "")).get());

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -178,7 +178,8 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(
                         Settings.builder().put(indexSettings())
                                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0))
+                                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false"))
         );
         ensureGreen("test");
         ClusterState state = client().admin().cluster().prepareState().get().getState();
@@ -385,7 +386,9 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
 
         final int numShards = scaledRandomIntBetween(2, 10);
         assertAcked(prepareCreate("test")
-                        .setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numShards))
+                        .setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numShards)
+                            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false"))
         );
         ensureGreen("test");
 

--- a/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -142,7 +142,11 @@ public class FullRollingRestartIT extends ESIntegTestCase {
          * to relocating to the restarting node since all had 2 shards and now one node has nothing allocated.
          * We have a fix for this to wait until we have allocated unallocated shards now so this shouldn't happen.
          */
-        prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "6").put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "0").put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(1))).get();
+        prepareCreate("test").setSettings(Settings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "6")
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "0")
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
+            .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(1))).get();
 
         for (int i = 0; i < 100; i++) {
             client().prepareIndex("test", "type1", Long.toString(i))

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -108,6 +109,7 @@ public class RelocationIT extends ESIntegTestCase {
                 .setSettings(Settings.builder()
                                 .put("index.number_of_shards", 1)
                                 .put("index.number_of_replicas", 0)
+                                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
                 )
                 .execute().actionGet();
 
@@ -162,6 +164,8 @@ public class RelocationIT extends ESIntegTestCase {
                 .setSettings(Settings.builder()
                                 .put("index.number_of_shards", 1)
                                 .put("index.number_of_replicas", numberOfReplicas)
+                                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                                .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE)
                 ).execute().actionGet();
 
 
@@ -265,6 +269,8 @@ public class RelocationIT extends ESIntegTestCase {
                 .setSettings(Settings.builder()
                         .put("index.number_of_shards", 1)
                         .put("index.number_of_replicas", numberOfReplicas)
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                        .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE)
                         .put("index.refresh_interval", -1) // we want to control refreshes c
                 ).execute().actionGet();
 
@@ -351,7 +357,12 @@ public class RelocationIT extends ESIntegTestCase {
         final String p_node = internalCluster().startNode();
 
         client().admin().indices().prepareCreate(indexName)
-                .setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)).get();
+                .setSettings(Settings.builder()
+                    .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                    .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE)
+                ).get();
 
         internalCluster().startNodesAsync(2).get();
 
@@ -440,6 +451,8 @@ public class RelocationIT extends ESIntegTestCase {
             .put("index.routing.allocation.exclude.color", "blue")
             .put(indexSettings())
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomInt(halfNodes - 1))
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
+            .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE)
         ));
         assertAllShardsOnNodes("test", redFuture.get().toArray(new String[2]));
         int numDocs = randomIntBetween(100, 150);

--- a/core/src/test/java/org/elasticsearch/recovery/TruncatedRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/TruncatedRecoveryIT.java
@@ -95,6 +95,7 @@ public class TruncatedRecoveryIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test")
                 .addMapping("type1", "field1", "type=text", "the_id", "type=text")
                 .setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numberOfShards())
+                        .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")
                         .put("index.routing.allocation.include._name", primariesNode.getNode().getName()))); // only allocate on the lucky node
 
         // index some docs and check if they are coming back

--- a/core/src/test/java/org/elasticsearch/search/preference/SearchPreferenceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/preference/SearchPreferenceIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestStatus;
@@ -40,11 +41,10 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.not;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class SearchPreferenceIT extends ESIntegTestCase {
@@ -131,7 +131,8 @@ public class SearchPreferenceIT extends ESIntegTestCase {
     }
 
     public void testReplicaPreference() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings("{\"number_of_replicas\": 0}").get();
+        client().admin().indices().prepareCreate("test").setSettings(
+            IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, false).get();
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "value1").execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/scroll/DuelScrollIT.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/DuelScrollIT.java
@@ -232,6 +232,7 @@ public class DuelScrollIT extends ESIntegTestCase {
         }
         // no replicas, as they might be ordered differently
         settings.put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0);
+        settings.put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false");
 
         assertAcked(prepareCreate("test").setSettings(settings.build()).get());
         final int numDocs = randomIntBetween(10, 200);

--- a/core/src/test/java/org/elasticsearch/search/stats/SearchStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/stats/SearchStatsIT.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -93,7 +94,8 @@ public class SearchStatsIT extends ESIntegTestCase {
         assertThat(numNodes, lessThanOrEqualTo(shardsIdx1 + shardsIdx2));
         assertAcked(prepareCreate("test1").setSettings(Settings.builder()
                 .put(SETTING_NUMBER_OF_SHARDS, shardsIdx1)
-                .put(SETTING_NUMBER_OF_REPLICAS, 0)));
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(SETTING_AUTO_EXPAND_REPLICAS, "false")));
         int docsTest1 = scaledRandomIntBetween(3*shardsIdx1, 5*shardsIdx1);
         for (int i = 0; i < docsTest1; i++) {
             client().prepareIndex("test1", "type", Integer.toString(i)).setSource("field", "value").execute().actionGet();
@@ -103,7 +105,8 @@ public class SearchStatsIT extends ESIntegTestCase {
         }
         assertAcked(prepareCreate("test2").setSettings(Settings.builder()
                 .put(SETTING_NUMBER_OF_SHARDS, shardsIdx2)
-                .put(SETTING_NUMBER_OF_REPLICAS, 0)));
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(SETTING_AUTO_EXPAND_REPLICAS, "false")));
         int docsTest2 = scaledRandomIntBetween(3*shardsIdx2, 5*shardsIdx2);
         for (int i = 0; i < docsTest2; i++) {
             client().prepareIndex("test2", "type", Integer.toString(i)).setSource("field", "value").execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -2767,7 +2767,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             // the less the number of shards, the less control files we have, so we are giving a higher probability of
             // triggering an IOException toward the end when writing the pending-index-* files, which are the files
             // that caused problems with writing subsequent snapshots if they happened to be lingering in the repository
-            Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0)));
+            Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "false")));
         ensureGreen();
         final int numDocs = randomIntBetween(1, 5);
         for (int i = 0; i < numDocs; i++) {

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -415,6 +415,8 @@ Returns:
     "settings": {
       "index.number_of_replicas": "1",
       "index.number_of_shards": "1",
+      "index.auto_expand_replicas": "false",
+      "index.write.wait_for_active_shards": "1",
       "index.creation_date": "1474389951325",
       "index.uuid": "n6gzFZTgS664GUfx0Xrpjw",
       "index.version.created": ...,
@@ -447,6 +449,10 @@ Returns:
       "index" : {
         "number_of_replicas": "1",
         "number_of_shards": "1",
+        "auto_expand_replicas": "false",
+        "write": {
+          "wait_for_active_shards": "1"
+        },
         "creation_date": "1474389951325",
         "uuid": "n6gzFZTgS664GUfx0Xrpjw",
         "version": {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -53,6 +53,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
@@ -168,8 +169,10 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
 import static org.elasticsearch.client.Requests.syncedFlushRequest;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS;
 import static org.elasticsearch.common.util.CollectionUtils.eagerPartition;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.XContentTestUtils.convertToMap;
@@ -695,6 +698,8 @@ public abstract class ESIntegTestCase extends ESTestCase {
         }
         // always default delayed allocation to 0 to make sure we have tests are not delayed
         builder.put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), 0);
+        builder.put(SETTING_AUTO_EXPAND_REPLICAS, "false");
+        builder.put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE);
         return builder.build();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -20,7 +20,8 @@
 package org.elasticsearch.test.rest.yaml;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.StringEntity;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.SuppressForbidden;
@@ -30,11 +31,10 @@ import org.elasticsearch.test.rest.yaml.parser.ClientYamlTestParseException;
 import org.elasticsearch.test.rest.yaml.parser.ClientYamlTestSuiteParser;
 import org.elasticsearch.test.rest.yaml.restspec.ClientYamlSuiteRestApi;
 import org.elasticsearch.test.rest.yaml.restspec.ClientYamlSuiteRestSpec;
+import org.elasticsearch.test.rest.yaml.section.ClientYamlTestSection;
 import org.elasticsearch.test.rest.yaml.section.ClientYamlTestSuite;
 import org.elasticsearch.test.rest.yaml.section.DoSection;
 import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
-import org.elasticsearch.test.rest.yaml.section.SkipSection;
-import org.elasticsearch.test.rest.yaml.section.ClientYamlTestSection;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -275,6 +275,21 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
         //skip test if test section is disabled
         assumeFalse(testCandidate.getTestSection().getSkipSection().getSkipMessage(testCandidate.getTestPath()),
                 testCandidate.getTestSection().getSkipSection().skip(restTestExecutionContext.esVersion()));
+
+        setupDefaultsTemplate();
+    }
+
+    private void setupDefaultsTemplate() throws IOException {
+        HttpEntity body = new StringEntity("{\n" +
+            "          \"template\": \"*\",\n" +
+            "          \"settings\": {\n" +
+            "            \"auto_expand_replicas\": \"false\",\n" +
+            "            \"write\": {\n" +
+            "              \"wait_for_active_shards\": 1\n" +
+            "            }\n" +
+            "          }\n" +
+            "        }");
+        adminClient().performRequest("PUT", "_template/defaults_template", Collections.emptyMap(), body);
     }
 
     public void test() throws IOException {


### PR DESCRIPTION
Also changes default of auto_expand_replicas to “0-1“.
This ensures that an index can be created and used with default settings
even on 1 node.