### PR TITLE
reverts _uid field type back to StringFieldType to re-enable range queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
@@ -76,7 +76,7 @@ public class UidFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    static final class UidFieldType extends TermBasedFieldType {
+    static final class UidFieldType extends StringFieldType {
 
         public UidFieldType() {
         }

--- a/core/src/test/java/org/elasticsearch/index/mapper/UidFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/UidFieldTypeTests.java
@@ -18,20 +18,9 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.UidFieldMapper;
-
 public class UidFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
         return new UidFieldMapper.UidFieldType();
-    }
-
-    public void testRangeQuery() {
-        MappedFieldType ft = createDefaultFieldType();
-        ft.setName("_uid");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> ft.rangeQuery(null, null, randomBoolean(), randomBoolean()));
-        assertEquals("Field [_uid] of type [_uid] does not support range queries", e.getMessage());
     }
 }


### PR DESCRIPTION
The _uid field type changed to a TermBasedField type, which disables range queries.
(see https://github.com/elastic/elasticsearch/commit/864ed04059f79a91a6680ee879f38182b5228865#diff-c2e85a078466dda30c38d573ac311b41)
The reason for that (_uid's encoding will maybe change in future) is currently not valid, so lets revert it.