### PR TITLE
Change default value calculation of gateway.recover_after_time

### DIFF
--- a/core/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -60,8 +60,22 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
         Setting.intSetting("gateway.expected_data_nodes", -1, -1, Property.NodeScope);
     public static final Setting<Integer> EXPECTED_MASTER_NODES_SETTING =
         Setting.intSetting("gateway.expected_master_nodes", -1, -1, Property.NodeScope);
+
+    static final TimeValue DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET = TimeValue.timeValueMinutes(5);
     public static final Setting<TimeValue> RECOVER_AFTER_TIME_SETTING =
-        Setting.positiveTimeSetting("gateway.recover_after_time", TimeValue.timeValueMillis(0), Property.NodeScope);
+        Setting.timeSetting(
+            "gateway.recover_after_time",
+            settings -> {
+                if (EXPECTED_NODES_SETTING.exists(settings)
+                    || EXPECTED_DATA_NODES_SETTING.exists(settings)
+                    || EXPECTED_MASTER_NODES_SETTING.exists(settings)) {
+                    return DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET;
+                }
+                return TimeValue.timeValueMillis(0);
+            },
+            TimeValue.ZERO,
+            Property.NodeScope
+        );
     public static final Setting<Integer> RECOVER_AFTER_NODES_SETTING =
         Setting.intSetting("gateway.recover_after_nodes", -1, -1, Property.NodeScope);
     public static final Setting<Integer> RECOVER_AFTER_DATA_NODES_SETTING =
@@ -71,7 +85,6 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
 
     public static final ClusterBlock STATE_NOT_RECOVERED_BLOCK = new ClusterBlock(1, "state not recovered / initialized", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);
 
-    public static final TimeValue DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET = TimeValue.timeValueMinutes(5);
 
     private final Gateway gateway;
 

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
@@ -29,6 +29,8 @@ import org.hamcrest.Matchers;
 
 import java.io.IOException;
 
+import static org.hamcrest.core.Is.is;
+
 public class GatewayServiceTests extends ESTestCase {
 
     private GatewayService createService(Settings.Builder settings) {
@@ -61,5 +63,21 @@ public class GatewayServiceTests extends ESTestCase {
         // ensure default is set when setting expected_nodes
         service = createService(Settings.builder().put("gateway.expected_nodes", 1).put("gateway.recover_after_time", timeValue.toString()));
         assertThat(service.recoverAfterTime().millis(), Matchers.equalTo(timeValue.millis()));
+    }
+
+    public void testRecoverAfterTimeDefaultValue() throws Exception {
+        assertThat(GatewayService.RECOVER_AFTER_TIME_SETTING.get(Settings.EMPTY).getSeconds(), is(0L));
+
+        assertThat(GatewayService.RECOVER_AFTER_TIME_SETTING.get(
+            Settings.builder().put(
+                GatewayService.RECOVER_AFTER_TIME_SETTING.getKey(), TimeValue.timeValueMinutes(2).toString()).build()
+        ).getMinutes(), is(2L));
+
+        assertThat(GatewayService.RECOVER_AFTER_TIME_SETTING.get(
+            Settings.builder().put(GatewayService.EXPECTED_NODES_SETTING.getKey(), 2).build()).getMinutes(), is(5L));
+        assertThat(GatewayService.RECOVER_AFTER_TIME_SETTING.get(
+            Settings.builder().put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 2).build()).getMinutes(), is(5L));
+        assertThat(GatewayService.RECOVER_AFTER_TIME_SETTING.get(
+            Settings.builder().put(GatewayService.EXPECTED_MASTER_NODES_SETTING.getKey(), 2).build()).getMinutes(), is(5L));
     }
 }


### PR DESCRIPTION
It's now correctly returning 5m if any of the expected_nodes settings
are set, instead of always returning 0m.