### PR TITLE
allow to set different name for setting option for EnvironmentAwareCommand

### DIFF
--- a/core/src/main/java/org/elasticsearch/cli/EnvironmentAwareCommand.java
+++ b/core/src/main/java/org/elasticsearch/cli/EnvironmentAwareCommand.java
@@ -36,8 +36,14 @@ public abstract class EnvironmentAwareCommand extends Command {
     private final OptionSpec<KeyValuePair> settingOption;
 
     public EnvironmentAwareCommand(String description) {
+        this(description, "E");
+    }
+
+    public EnvironmentAwareCommand(String description, String settingOptionName) {
         super(description);
-        this.settingOption = parser.accepts("E", "Configure a setting").withRequiredArg().ofType(KeyValuePair.class);
+        this.settingOption = parser.accepts(settingOptionName, "Configure a setting")
+            .withRequiredArg()
+            .ofType(KeyValuePair.class);
     }
 
     @Override


### PR DESCRIPTION
to allow a different settingsOption name than "E"
this is for CrateDB to allow the "-C" command line argument