### PR TITLE
Improve error message for missing setting.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -287,8 +287,8 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
             if (keys.isEmpty() == false) {
                 msg += " did you mean " + (keys.size() == 1 ? "[" + keys.get(0) + "]": "any of " + keys.toString()) + "?";
             } else {
-                msg += " please check that any required plugins are installed, or check the breaking changes documentation for removed " +
-                    "settings";
+                msg += " please check that any required plugins are installed or `license.enterprise` is enabled, " +
+                    "if the plugin(s) require(s) it, or check the breaking changes documentation for removed settings";
             }
             throw new IllegalArgumentException(msg);
         }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -62,8 +62,9 @@ public class CreateIndexIT extends ESIntegTestCase {
             prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_CREATION_DATE, 4L)).get();
             fail();
         } catch (IllegalArgumentException ex) {
-            assertEquals("unknown setting [index.creation_date] please check that any required plugins are installed, or check the " +
-                "breaking changes documentation for removed settings", ex.getMessage());
+            assertEquals("unknown setting [index.creation_date] please check that any required plugins are installed " +
+                         "or `license.enterprise` is enabled, if the plugin(s) require(s) it, or check the breaking " +
+                         "changes documentation for removed settings", ex.getMessage());
         }
     }
 
@@ -158,8 +159,9 @@ public class CreateIndexIT extends ESIntegTestCase {
                 .get();
             fail("should have thrown an exception about the shard count");
         } catch (IllegalArgumentException e) {
-            assertEquals("unknown setting [index.unknown.value] please check that any required plugins are installed, or check the" +
-                " breaking changes documentation for removed settings", e.getMessage());
+            assertEquals("unknown setting [index.unknown.value] please check that any required plugins are installed " +
+                         "or `license.enterprise` is enabled, if the plugin(s) require(s) it, or check the breaking " +
+                         "changes documentation for removed settings", e.getMessage());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -443,8 +443,8 @@ public class ScopedSettingsTests extends ESTestCase {
         IndexScopedSettings settings = new IndexScopedSettings(
             Settings.EMPTY,
             IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
-        String unknownMsgSuffix = " please check that any required plugins are installed, or check the breaking changes documentation for" +
-            " removed settings";
+        String unknownMsgSuffix = " please check that any required plugins are installed or `license.enterprise` is " +
+            "enabled, if the plugin(s) require(s) it, or check the breaking changes documentation for removed settings";
         settings.validate(Settings.builder().put("index.store.type", "boom"));
         settings.validate(Settings.builder().put("index.store.type", "boom").build());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
@@ -51,8 +51,9 @@ public class SettingsModuleTests extends ModuleTestCase {
                 () -> new SettingsModule(settings));
             assertEquals("Failed to parse value [[2.0]] for setting [cluster.routing.allocation.balance.shard]", ex.getMessage());
             assertEquals(1, ex.getSuppressed().length);
-            assertEquals("unknown setting [some.foo.bar] please check that any required plugins are installed, or check the breaking " +
-                "changes documentation for removed settings", ex.getSuppressed()[0].getMessage());
+            assertEquals("unknown setting [some.foo.bar] please check that any required plugins are installed or " +
+                "`license.enterprise` is enabled, if the plugin(s) require(s) it, or check the breaking changes " +
+                "documentation for removed settings", ex.getSuppressed()[0].getMessage());
         }
 
         {
@@ -129,7 +130,8 @@ public class SettingsModuleTests extends ModuleTestCase {
                 fail();
             } catch (IllegalArgumentException ex) {
                 assertEquals("tribe.blocks validation failed: unknown setting [wtf] please check that any required plugins are" +
-                    " installed, or check the breaking changes documentation for removed settings", ex.getMessage());
+                    " installed or `license.enterprise` is enabled, if the plugin(s) require(s) it, or check the " +
+                    "breaking changes documentation for removed settings", ex.getMessage());
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -359,8 +359,9 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                 .setTemplate("te*")
                 .setSettings(Settings.builder().put("does_not_exist", "test"))
                 .get());
-        assertEquals("unknown setting [index.does_not_exist] please check that any required plugins are" +
-            " installed, or check the breaking changes documentation for removed settings", e.getMessage());
+        assertEquals("unknown setting [index.does_not_exist] please check that any required plugins are installed or " +
+            "`license.enterprise` is enabled, if the plugin(s) require(s) it, or check the breaking changes " +
+            "documentation for removed settings", e.getMessage());
 
         response = client().admin().indices().prepareGetTemplates().get();
         assertEquals(0, response.getIndexTemplates().size());


### PR DESCRIPTION
Inform user that `license.enterprise` should be enabled if enterprise plugin(s) are loaded.