### PR TITLE
Update nondata node test so that it passes ES61

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/NonDataNodeShardRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/NonDataNodeShardRoutingTests.java
@@ -1,23 +1,20 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
- *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.cluster.routing.allocation;
@@ -49,7 +46,6 @@ import static java.util.Collections.emptyMap;
 public class NonDataNodeShardRoutingTests extends ESAllocationTestCase {
     private final Logger logger = Loggers.getLogger(NonDataNodeShardRoutingTests.class);
 
-    @Test(expected = IllegalArgumentException.class)
     public void testMoveShardToNonDataNode() {
         MetaData metaData = MetaData.builder()
             .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(2).numberOfReplicas(1))
@@ -74,10 +70,9 @@ public class NonDataNodeShardRoutingTests extends ESAllocationTestCase {
         RoutingAllocation routingAllocation = new RoutingAllocation(new AllocationDeciders(Settings.EMPTY, Collections.emptyList()),
             new RoutingNodes(clusterState, false), clusterState, ClusterInfo.EMPTY, System.nanoTime());
         logger.info("--> executing move allocation command to non-data node");
-        command.execute(routingAllocation, false);
+        expectThrows(IllegalArgumentException.class, () -> command.execute(routingAllocation, false));
     }
 
-    @Test(expected = IllegalArgumentException.class)
     public void testMoveShardFromNonDataNode() {
         MetaData metaData = MetaData.builder()
             .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(2).numberOfReplicas(1))
@@ -102,6 +97,6 @@ public class NonDataNodeShardRoutingTests extends ESAllocationTestCase {
         RoutingAllocation routingAllocation = new RoutingAllocation(new AllocationDeciders(Settings.EMPTY, Collections.emptyList()),
             new RoutingNodes(clusterState, false), clusterState, ClusterInfo.EMPTY, System.nanoTime());
         logger.info("--> executing move allocation command from non-data node");
-        command.execute(routingAllocation, false);
+        expectThrows(IllegalArgumentException.class, () -> command.execute(routingAllocation, false));
     }
 }


### PR DESCRIPTION
@mfussenegger Sorry to be a pain, but would you be able to run ``check`` on this branch? I'm pretty sure this resolves all the issues that the ES61 tests were having, but im unable to run check fully due to a consistent JVM crash that im pinning down.

Also, is there any way to squash this commit down with the previous ones or is it fine like this? I'm a little ashamed that I'm dumping 3 commits into the fork just to fix a small bug. :sweat_smile: 