### PR TITLE
Make S3 credential settings insecure so they can be set in the yml file.

### DIFF
--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -65,8 +65,8 @@ test {
 }
 
 integTestCluster {
-  keystoreSetting 's3.client.default.access_key', 'myaccesskey'
-  keystoreSetting 's3.client.default.secret_key', 'mysecretkey'
+  setting 's3.client.default.access_key', 'myaccesskey'
+  setting 's3.client.default.secret_key', 'mysecretkey'
 }
 
 thirdPartyAudit.excludes = [

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -44,12 +44,12 @@ class S3ClientSettings {
     private static final String PREFIX = "s3.client.";
 
     /** The access key (ie login id) for connecting to s3. */
-    static final Setting.AffixSetting<SecureString> ACCESS_KEY_SETTING = Setting.affixKeySetting(PREFIX, "access_key",
-        key -> SecureSetting.secureString(key, null));
+    static final Setting.AffixSetting<SecureString> ACCESS_KEY_SETTING =
+        Setting.affixKeySetting(PREFIX, "access_key", SecureSetting::insecureString);
 
     /** The secret key (ie password) for connecting to s3. */
-    static final Setting.AffixSetting<SecureString> SECRET_KEY_SETTING = Setting.affixKeySetting(PREFIX, "secret_key",
-        key -> SecureSetting.secureString(key, null));
+    static final Setting.AffixSetting<SecureString> SECRET_KEY_SETTING =
+        Setting.affixKeySetting(PREFIX, "secret_key", SecureSetting::insecureString);
 
     /** An override for the s3 endpoint to connect to. */
     static final Setting.AffixSetting<String> ENDPOINT_SETTING = Setting.affixKeySetting(PREFIX, "endpoint",
@@ -68,12 +68,12 @@ class S3ClientSettings {
         key -> Setting.intSetting(key, 80, 0, 1<<16, Property.NodeScope));
 
     /** The username of a proxy to connect to s3 through. */
-    static final Setting.AffixSetting<SecureString> PROXY_USERNAME_SETTING = Setting.affixKeySetting(PREFIX, "proxy.username",
-        key -> SecureSetting.secureString(key, null));
+    static final Setting.AffixSetting<SecureString> PROXY_USERNAME_SETTING =
+        Setting.affixKeySetting(PREFIX, "proxy.username", SecureSetting::insecureString);
 
     /** The password of a proxy to connect to s3 through. */
-    static final Setting.AffixSetting<SecureString> PROXY_PASSWORD_SETTING = Setting.affixKeySetting(PREFIX, "proxy.password",
-        key -> SecureSetting.secureString(key, null));
+    static final Setting.AffixSetting<SecureString> PROXY_PASSWORD_SETTING =
+        Setting.affixKeySetting(PREFIX, "proxy.password", SecureSetting::insecureString);
 
     /** The socket timeout for connecting to s3. */
     static final Setting.AffixSetting<TimeValue> READ_TIMEOUT_SETTING = Setting.affixKeySetting(PREFIX, "read_timeout",

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
@@ -23,7 +23,6 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
@@ -41,21 +40,21 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     }
 
     public void testAwsCredsDefaultSettings() {
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString("s3.client.default.access_key", "aws_key");
-        secureSettings.setString("s3.client.default.secret_key", "aws_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
+        Settings settings = Settings.builder()
+                                    .put("s3.client.default.access_key", "aws_key")
+                                    .put("s3.client.default.secret_key", "aws_secret")
+                                    .build();
         assertCredentials(Settings.EMPTY, settings, "aws_key", "aws_secret");
     }
 
     public void testAwsCredsExplicitConfigSettings() {
         Settings repositorySettings = Settings.builder().put(InternalAwsS3Service.CLIENT_NAME.getKey(), "myconfig").build();
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString("s3.client.myconfig.access_key", "aws_key");
-        secureSettings.setString("s3.client.myconfig.secret_key", "aws_secret");
-        secureSettings.setString("s3.client.default.access_key", "wrong_key");
-        secureSettings.setString("s3.client.default.secret_key", "wrong_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
+        Settings settings = Settings.builder()
+                                    .put("s3.client.myconfig.access_key", "aws_key")
+                                    .put("s3.client.myconfig.secret_key", "aws_secret")
+                                    .put("s3.client.default.access_key", "wrong_key")
+                                    .put("s3.client.default.secret_key", "wrong_secret")
+                                    .build();
         assertCredentials(repositorySettings, settings, "aws_key", "aws_secret");
     }
 
@@ -89,11 +88,9 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     }
 
     public void testAWSConfigurationWithAwsSettings() {
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString("s3.client.default.proxy.username", "aws_proxy_username");
-        secureSettings.setString("s3.client.default.proxy.password", "aws_proxy_password");
         Settings settings = Settings.builder()
-            .setSecureSettings(secureSettings)
+            .put("s3.client.default.proxy.username", "aws_proxy_username")
+            .put("s3.client.default.proxy.password", "aws_proxy_password")
             .put("s3.client.default.protocol", "http")
             .put("s3.client.default.proxy.host", "aws_proxy_host")
             .put("s3.client.default.proxy.port", 8080)


### PR DESCRIPTION
In order to avoid the need to use a keystore to store this settings
we'll keep these settings as insecure, as we do not want to introduce
the keystore requirement at this point.

Enabling `s3.client.*.access_key` and `s3.client.*.secret_key` is essential
as support for reading the credentials from environment variable or java
properites has been dropped.