### PR TITLE
Netty logging guard (again)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4InternalESLogger.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4InternalESLogger.java
@@ -101,7 +101,11 @@ class Netty4InternalESLogger extends AbstractInternalLogger {
 
     @Override
     public void info(String msg) {
-        logger.info(msg);
+        if (!("Your platform does not provide complete low-level API for accessing direct buffers reliably. " +
+              "Unless explicitly requested, heap buffer will always be preferred to avoid potential system " +
+              "instability.").equals(msg)) {
+            logger.info(msg);
+        }
     }
 
     @Override


### PR DESCRIPTION
This adds a hack to prevent Netty from logging a scary message when
unsafe is unavailable even that usage of unsafe is explicitly disabled.
This was already fixed at Netty a few times (see https://github.com/netty/netty/pull/5624 and https://github.com/netty/netty/pull/6696) but unfortunately
was introduced again by recent 4.1 refactoring.
This commit is a hack around this until we can get a fix upstream.

Relates https://github.com/netty/netty/pull/8111, https://github.com/elastic/elasticsearch/pull/24469, https://github.com/elastic/elasticsearch/pull/24653