### PR TITLE
Add support for configuring features on the json generator.

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentGenerator.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentGenerator.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.common.xcontent;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
@@ -169,4 +171,7 @@ public interface XContentGenerator extends Closeable, Flushable {
      */
     boolean isClosed();
 
+    void configure(JsonGenerator.Feature f, boolean state);
+
+    boolean isEnabled(JsonGenerator.Feature f);
 }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java
@@ -513,4 +513,14 @@ public class JsonXContentGenerator implements XContentGenerator {
             }
         }
     }
+
+    @Override
+    public void configure(JsonGenerator.Feature f, boolean state) {
+        generator.configure(f, state);
+    }
+
+    @Override
+    public boolean isEnabled(JsonGenerator.Feature f) {
+        return generator.isEnabled(f);
+    }
 }


### PR DESCRIPTION
Sometimes it is required to configure some features on individual
json generator instances, e.g. to disable output that flush() calls
will call flush() in the output stream (this is unwanted when e.g.
using buffered output streams).